### PR TITLE
fix minor typo in function.mdx

### DIFF
--- a/docs/pages/function.mdx
+++ b/docs/pages/function.mdx
@@ -74,7 +74,7 @@ assertEquals(result, 9);
 
 ## compose
 
-The `compose` function is similar to the `pipe` function, but instead of returning the result of the pipelime, it chains all the functions passed to it into a single function.
+The `compose` function is similar to the `pipe` function, but instead of returning the result of the pipeline, it chains all the functions passed to it into a single function.
 
 ### Import
 


### PR DESCRIPTION
### Description
- fixes `pipelime` to `pipeline`.  in functions docs.